### PR TITLE
使用Live edit插件修网页外部css文件时在chrome中无法显示变化效果

### DIFF
--- a/FAQ/问题集合/插件/使用Live edit插件修网页外部css文件无法即时显示变化效果.md
+++ b/FAQ/问题集合/插件/使用Live edit插件修网页外部css文件无法即时显示变化效果.md
@@ -13,8 +13,9 @@
 
 
 * **引起问题的原因**；
->问题源于chromium的一次更新,详情请看 >http://src.chromium.org/viewvc/blink/trunk/Source/devtools/protocol.json?revision=166228
->以下是官方的live edit讨论区对于这个问题的谈论，第一条评论指出的问题所在。 >http://youtrack.jetbrains.com/issue/WEB-11393#comment=27-722471
+>问题源于chromium的一次更新,详情请看
+http://src.chromium.org/viewvc/blink/trunk/Source/devtools/protocol.json?revision=166228    
+以下是官方的live edit讨论区对于这个问题的谈论，第一条评论指出的问题所在。 http://youtrack.jetbrains.com/issue/WEB-11393#comment=27-722471
 
 
 


### PR DESCRIPTION
使用Live edit插件修网页外部css文件时在chrome中无法显示变化效果
